### PR TITLE
Add client directive to Footer component

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import Link from 'next/link'
 import {useLocale, useTranslations} from 'next-intl'
 


### PR DESCRIPTION
## Summary
- add the `'use client'` directive so the footer can safely call `useTranslations` and `useLocale`

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e0242fa17c83219cb7a7e81eb40f86